### PR TITLE
Adjust user endpoints, fix httpOnly cookie bugs, minor changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ nuke: ## Bring down the docker containers and delete volumes
 	@echo "Running make $@..."
 	docker compose --file=docker-compose.yml --file=docker-compose.test.yml down --volumes
 
+refresh: down build up ## Bring down containers, rebuild, bring up again
+
 hard-refresh: nuke build up ## Bring down containers, nuke volumes, rebuild, bring up again
+
 
 lint: ## Run both lint-format and lint-check
 	@echo "Running make $@..."

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ down: ## Bring down the docker containers
 	@echo "Running make $@..."
 	docker compose --file=docker-compose.yml --file=docker-compose.test.yml down
 
+nuke: ## Bring down the docker containers and delete volumes
+	@echo "Running make $@..."
+	docker compose --file=docker-compose.yml --file=docker-compose.test.yml down --volumes
+
+hard-refresh: nuke build up ## Bring down containers, nuke volumes, rebuild, bring up again
+
 lint: ## Run both lint-format and lint-check
 	@echo "Running make $@..."
 	make lint-format

--- a/purch/api/routers/user.py
+++ b/purch/api/routers/user.py
@@ -1,8 +1,9 @@
+from jose.exceptions import JWTError
 import plaid
 
 from taskiq import TaskiqResultTimeoutError
 from typing import Annotated
-from fastapi import APIRouter, Response, Depends, status
+from fastapi import APIRouter, Request, Response, Depends, status
 
 from fastapi.security import OAuth2PasswordRequestForm
 
@@ -12,7 +13,7 @@ from purch.common.config import get_settings, Settings
 from purch.common.dependencies import get_user_service
 from purch.domains.models import User
 from purch.infrastructure.auth.schemas import Token
-from purch.infrastructure.auth.service import get_current_active_user
+from purch.infrastructure.auth.service import get_current_active_user, verify_purch_jwt_token
 from purch.infrastructure.plaid.tokens import (
     get_plaid_access_token,
     get_plaid_link_token,
@@ -31,14 +32,14 @@ async def get_current_user(
     return current_user
 
 
-@router.post("/token")
-async def login_for_access_token(
-    response: Response,
+@router.post("/login")
+async def new_auth_cookie(
+    # response: Response,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     user_service: Annotated[UserService, Depends(get_user_service)],
 ):
     """
-    Login for access token.
+    Generate purch auch cookie if login credentials are valid.
     """
     try:
         token: Token = user_service.get_purch_jwt_access_token(form_data)
@@ -49,8 +50,10 @@ async def login_for_access_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    user_service.set_user_active_status(form_data.username, True)
+    response = Response(status_code=status.HTTP_200_OK, content="User logged in successfully")
     response.set_cookie(
-        key="access_token",
+        key=user_service.settings.AUTH_COOKIE_NAME,
         value=token.access_token,
         httponly=True,
         secure=True,
@@ -59,17 +62,44 @@ async def login_for_access_token(
         path="/",
     )
 
+    return response;
+
+@router.post("/verify_auth")
+async def verify_auth_cookie(
+    request: Request,
+    user_service: Annotated[UserService, Depends(get_user_service)],
+    _: Annotated[User, Depends(get_current_active_user)],
+):
+    """
+    Verify purch auth cookie.
+    """
+    token = request.cookies.get(user_service.settings.AUTH_COOKIE_NAME)
+    if not token:
+        return Response(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            content="No authentication cookie found"
+        )
+
+    try:
+        verify_purch_jwt_token(token, user_service.settings)
+    except JWTError:
+        return Response(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            content="Invalid or expired Purch token"
+        )
     return Response(
-        status_code=status.HTTP_200_OK, content="User logged in successfully"
+        status_code=status.HTTP_200_OK,
+        content="User successfully authenticated"
     )
 
 
 @router.post("/logout")
 def logout(response: Response,
     user: Annotated[User, Depends(get_current_active_user)],
+    user_service: Annotated[UserService, Depends(get_user_service)],
     ):
-    user.is_active = False
-    response.delete_cookie("access_token", path="/")
+    user_service.user_repo.set_active_status(user, False)
+    response.delete_cookie(user_service.settings.AUTH_COOKIE_NAME, path="/")
     return Response(
         status_code=status.HTTP_200_OK, content="User logged out successfully"
     )

--- a/purch/api/routers/user.py
+++ b/purch/api/routers/user.py
@@ -1,11 +1,9 @@
-import uuid
 import plaid
 
 from taskiq import TaskiqResultTimeoutError
 from typing import Annotated
-from fastapi import APIRouter, Response, Depends, HTTPException, status
+from fastapi import APIRouter, Response, Depends, status
 
-from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from purch.domains.user.service import UserService
@@ -33,7 +31,7 @@ async def get_current_user(
     return current_user
 
 
-@router.post("/token", response_model=Response)
+@router.post("/token")
 async def login_for_access_token(
     response: Response,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
@@ -61,13 +59,11 @@ async def login_for_access_token(
         path="/",
     )
 
-    return Response(
-        status_code=status.HTTP_200_OK, content="User logged in successfully"
-    )
+    return response
 
 
-@router.post("/logout", response_model=Response)
-def logout(response: Response) -> Response:
+@router.post("/logout")
+def logout(response: Response):
     response.delete_cookie("access_token", path="/")
     return Response(
         status_code=status.HTTP_200_OK, content="User logged out successfully"

--- a/purch/api/routers/user.py
+++ b/purch/api/routers/user.py
@@ -1,11 +1,9 @@
-import uuid
 import plaid
 
 from taskiq import TaskiqResultTimeoutError
 from typing import Annotated
-from fastapi import APIRouter, Response, Depends, HTTPException, status
+from fastapi import APIRouter, Response, Depends, status
 
-from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from purch.domains.user.service import UserService
@@ -33,18 +31,18 @@ async def get_current_user(
     return current_user
 
 
-@router.post("/token", response_model=Response)
+@router.post("/token")
 async def login_for_access_token(
     response: Response,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     user_service: Annotated[UserService, Depends(get_user_service)],
-) -> Response:
+):
     """
     Login for access token.
     """
     try:
         token: Token = user_service.get_purch_jwt_access_token(form_data)
-    except ValueError as e:
+    except ValueError:
         return Response(
             status_code=status.HTTP_401_UNAUTHORIZED,
             content="Incorrect username or password",
@@ -66,8 +64,11 @@ async def login_for_access_token(
     )
 
 
-@router.post("/logout", response_model=Response)
-def logout(response: Response) -> Response:
+@router.post("/logout")
+def logout(response: Response,
+    user: Annotated[User, Depends(get_current_active_user)],
+    ):
+    user.is_active = False
     response.delete_cookie("access_token", path="/")
     return Response(
         status_code=status.HTTP_200_OK, content="User logged out successfully"

--- a/purch/api/routers/user.py
+++ b/purch/api/routers/user.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from purch.domains.user.service import UserService
-from purch.domains.user.schemas import LoginLogoutResponse, UserCreate, UserResponse, UserUpdate, UserDelete
+from purch.domains.user.schemas import UserCreate, UserResponse, UserUpdate, UserDelete
 from purch.common.config import get_settings, Settings
 from purch.common.dependencies import get_user_service
 from purch.domains.models import User

--- a/purch/api/routers/user.py
+++ b/purch/api/routers/user.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from purch.domains.user.service import UserService
-from purch.domains.user.schemas import UserCreate, UserResponse, UserUpdate, UserDelete
+from purch.domains.user.schemas import LoginLogoutResponse, UserCreate, UserResponse, UserUpdate, UserDelete
 from purch.common.config import get_settings, Settings
 from purch.common.dependencies import get_user_service
 from purch.domains.models import User
@@ -33,11 +33,12 @@ async def get_current_user(
     return current_user
 
 
-@router.post("/token", response_model=Token)
+@router.post("/token", response_model=Response)
 async def login_for_access_token(
+    response: Response,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     user_service: Annotated[UserService, Depends(get_user_service)],
-) -> Token:
+) -> Response:
     """
     Login for access token.
     """
@@ -49,7 +50,30 @@ async def login_for_access_token(
             content="Incorrect username or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    return token
+
+    response.set_cookie(
+        key="access_token",
+        value=token.access_token,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=user_service.settings.AUTH_ACCESS_TOKEN_EXPIRE_MINUTES,
+        path="/",
+    )
+
+    return Response(
+        status_code=status.HTTP_200_OK,
+        content="User logged in successfully"
+    )
+
+
+@router.post("/logout", response_model=Response)
+def logout(response: Response) -> Response:
+    response.delete_cookie("access_token", path="/")
+    return Response(
+        status_code=status.HTTP_200_OK,
+        content="User logged out successfully"
+    )
 
 
 @router.post("/register", response_model=UserResponse)

--- a/purch/api/routers/user.py
+++ b/purch/api/routers/user.py
@@ -56,14 +56,13 @@ async def login_for_access_token(
         value=token.access_token,
         httponly=True,
         secure=True,
-        samesite="lax",
+        samesite="strict",
         max_age=user_service.settings.AUTH_ACCESS_TOKEN_EXPIRE_MINUTES,
         path="/",
     )
 
     return Response(
-        status_code=status.HTTP_200_OK,
-        content="User logged in successfully"
+        status_code=status.HTTP_200_OK, content="User logged in successfully"
     )
 
 
@@ -71,8 +70,7 @@ async def login_for_access_token(
 def logout(response: Response) -> Response:
     response.delete_cookie("access_token", path="/")
     return Response(
-        status_code=status.HTTP_200_OK,
-        content="User logged out successfully"
+        status_code=status.HTTP_200_OK, content="User logged out successfully"
     )
 
 

--- a/purch/common/config.py
+++ b/purch/common/config.py
@@ -56,6 +56,7 @@ class Settings(BaseSettings):
     AUTH_ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(
         default=30, description="time, in minutes, the jwt lasts per user"
     )
+    AUTH_COOKIE_NAME: str = Field("purch_token")
 
     # Secret key for JWT signing
     SECRET_KEY: SecretStr = Field(description="secret key used for password encryption")

--- a/purch/domains/models.py
+++ b/purch/domains/models.py
@@ -24,13 +24,13 @@ class User(SQLModel, table=True):
     last_updated: float | None = Field(
         default_factory=dt.datetime.now(dt.timezone.utc).timestamp
     )
-    first_name: str = Field(default="Anders")
-    last_name: str = Field(default="Buch")
-    username: str = Field(default="anders.buch", index=True, unique=True)
-    password: str = Field(default="password")
-    is_active: bool = Field(default=True)
-    salary: decimal.Decimal = Field(default=decimal.Decimal(3958.33))
-    salary_rate: SalaryRates = Field(default=SalaryRates.bimonthly)
+    first_name: str = Field(...)
+    last_name: str = Field(...)
+    username: str = Field(index=True, unique=True)
+    password: str = Field(...)
+    is_active: bool = Field(...)
+    salary: decimal.Decimal = Field(...)
+    salary_rate: SalaryRates = Field(...)
 
     items: list["Item"] = Relationship(back_populates="user", cascade_delete=True)
     categories: list["Category"] = Relationship(
@@ -45,9 +45,9 @@ class Category(SQLModel, table=True):
         default_factory=uuid.uuid4, primary_key=True, unique=True
     )
     user_id: uuid.UUID = Field(index=True, foreign_key="users.id", nullable=False)
-    label: str = Field(default="Groceries")
-    current_spending: decimal.Decimal = Field(default=0)
-    budget: decimal.Decimal = Field(default=350)
+    label: str = Field(...)
+    current_spending: decimal.Decimal = Field(...)
+    budget: decimal.Decimal = Field(...)
 
     user: User = Relationship(back_populates="categories")
 
@@ -55,10 +55,10 @@ class Category(SQLModel, table=True):
 class Item(SQLModel, table=True):
     __tablename__ = "items"
 
-    id: str = Field(default="abc", primary_key=True, index=True, unique=True)
+    id: str = Field(primary_key=True, index=True, unique=True)
     user_id: uuid.UUID = Field(index=True, foreign_key="users.id", nullable=False)
     access_token: str = Field(nullable=False)
-    bank_name: str = Field(default="Capital One", nullable=False)
+    bank_name: str = Field(..., nullable=False)
     transaction_cursor: str | None = Field(default="")
 
     user: User = Relationship(back_populates="items")
@@ -68,9 +68,9 @@ class Item(SQLModel, table=True):
 class Account(SQLModel, table=True):
     __tablename__ = "accounts"
 
-    id: str = Field(default="def", primary_key=True, index=True, unique=True)
+    id: str = Field(primary_key=True, index=True, unique=True)
     item_id: str = Field(index=True, foreign_key="items.id", nullable=False)
-    name: str = Field(default="Venture X Credit Card")
+    name: str = Field(...)
 
     item: Item = Relationship(back_populates="accounts")
     transactions: list["Transaction"] = Relationship(
@@ -81,14 +81,14 @@ class Account(SQLModel, table=True):
 class Transaction(SQLModel, table=True):
     __tablename__ = "transactions"
 
-    id: str = Field(default="ghi", primary_key=True, index=True, unique=True)
+    id: str = Field(primary_key=True, index=True, unique=True)
     account_id: str = Field(index=True, foreign_key="accounts.id", nullable=False)
-    category: str = Field(default="Entertainment", index=True)
-    authorized_date: str = Field(default="2025-05-09", index=True)
-    settled_date: str | None = Field()
-    merchant_name: str | None = Field(default="Noah Kahan")
-    amount: decimal.Decimal = Field(default="100")
-    currency_code: str = Field("USD")
+    category: str = Field(index=True)
+    authorized_date: str = Field(index=True)
+    settled_date: str | None = Field(...)
+    merchant_name: str | None = Field(...)
+    amount: decimal.Decimal = Field(...)
+    currency_code: str = Field(default="US")
     pending: bool = Field(default=False)
 
     account: Account = Relationship(back_populates="transactions")

--- a/purch/domains/models.py
+++ b/purch/domains/models.py
@@ -6,7 +6,7 @@ from enum import StrEnum, auto
 from sqlmodel import SQLModel, Field, Relationship
 
 
-class SalaryRates(StrEnum):
+class IncomeRates(StrEnum):
     hourly = auto()
     weekly = auto()
     biweekly = auto()
@@ -24,13 +24,13 @@ class User(SQLModel, table=True):
     last_updated: float | None = Field(
         default_factory=dt.datetime.now(dt.timezone.utc).timestamp
     )
-    first_name: str = Field(default="Anders")
-    last_name: str = Field(default="Buch")
-    username: str = Field(default="anders.buch", index=True, unique=True)
-    password: str = Field(default="password")
-    is_active: bool = Field(default=True)
-    salary: decimal.Decimal = Field(default=decimal.Decimal(3958.33))
-    salary_rate: SalaryRates = Field(default=SalaryRates.bimonthly)
+    first_name: str = Field(...)
+    last_name: str = Field(...)
+    username: str = Field(..., index=True, unique=True)
+    password: str = Field(...)
+    is_active: bool | None = Field(default=False)
+    income: decimal.Decimal = Field(default=decimal.Decimal(0))
+    income_rate: IncomeRates = Field(default=IncomeRates.bimonthly)
 
     items: list["Item"] = Relationship(back_populates="user", cascade_delete=True)
     categories: list["Category"] = Relationship(

--- a/purch/domains/user/repository.py
+++ b/purch/domains/user/repository.py
@@ -61,9 +61,15 @@ class UserRepository(AbstractPostgresRepository):
                     last_name=updated_user.last_name,
                     username=updated_user.username,
                     password=updated_user.password,
-                    salary_rate=updated_user.salary_rate,
-                    salary=updated_user.salary,
+                    income_rate=updated_user.income_rate,
+                    income=updated_user.income,
                 )
             )
             session.exec(statement)
+            session.commit()
+
+    def set_active_status(self, user: User, is_active: bool):
+        user.is_active = is_active
+        with Session(self.engine) as session:
+            session.add(user)
             session.commit()

--- a/purch/domains/user/schemas.py
+++ b/purch/domains/user/schemas.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 
 from purch.domains.models import SalaryRates
 
-
 class UserCreate(BaseModel):
     username: str = "anders.buch"
     password: str = "password"

--- a/purch/domains/user/schemas.py
+++ b/purch/domains/user/schemas.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from purch.domains.models import SalaryRates
+from purch.domains.models import IncomeRates
 
 class UserCreate(BaseModel):
     username: str = "anders.buch"
@@ -19,8 +19,8 @@ class UserResponse(BaseModel):
     username: str
     first_name: str
     last_name: str
-    salary: Optional[decimal.Decimal] = None
-    salary_rate: Optional[SalaryRates] = None
+    income: Optional[decimal.Decimal] = None
+    income_rate: Optional[IncomeRates] = None
 
 
 class UserUpdate(BaseModel):
@@ -28,8 +28,8 @@ class UserUpdate(BaseModel):
     last_name: Optional[str] = None
     username: Optional[str] = None
     password: Optional[str] = None
-    salary_rate: Optional[SalaryRates] = None
-    salary: Optional[decimal.Decimal] = None
+    income_rate: Optional[IncomeRates] = None
+    income: Optional[decimal.Decimal] = None
 
 
 class UserDelete(BaseModel):

--- a/purch/domains/user/service.py
+++ b/purch/domains/user/service.py
@@ -58,8 +58,8 @@ class UserService:
             username=newly_created_user.username,
             first_name=newly_created_user.first_name,
             last_name=newly_created_user.last_name,
-            salary=newly_created_user.salary,
-            salary_rate=newly_created_user.salary_rate,
+            income=newly_created_user.income,
+            income_rate=newly_created_user.income_rate,
         )
 
     def get_purch_jwt_access_token(
@@ -87,29 +87,23 @@ class UserService:
         )
         return Token(access_token=access_token, token_type="bearer")
 
+
     def update_user(self, id: str | uuid.UUID, user_data: UserUpdate) -> UserResponse:
         """
         Update user information.
         """
         existing_user = self.user_repo.get_user_by_id(id=id)
+        existing_user.model_dump
 
         # If user does not exist, raise an exception
         if existing_user is None:
             raise ValueError("User not found or logged in...")
 
         # Update the user data
-        if user_data.first_name is not None:
-            existing_user.first_name = user_data.first_name
-        if user_data.last_name is not None:
-            existing_user.last_name = user_data.last_name
-        if user_data.username is not None:
-            existing_user.username = user_data.username
-        if user_data.password is not None:
-            existing_user.password = hash_password(user_data.password)
-        if user_data.salary_rate is not None:
-            existing_user.salary_rate = user_data.salary_rate
-        if user_data.salary is not None:
-            existing_user.salary = user_data.salary
+        for attr, val in user_data.model_dump().items():
+            if val is not None:
+                existing_user.val = val if attr != 'password' else hash_password(val)
+
 
         # Save the updated user back to the repository
         self.user_repo.update_user(existing_user)
@@ -119,8 +113,8 @@ class UserService:
             username=existing_user.username,
             first_name=existing_user.first_name,
             last_name=existing_user.last_name,
-            salary=existing_user.salary,
-            salary_rate=existing_user.salary_rate,
+            income=existing_user.income,
+            income_rate=existing_user.income_rate,
         )
 
     def delete_user(self, user: User) -> UserDelete:
@@ -189,3 +183,8 @@ class UserService:
             )
             self.user_repo.add_user_account(account)
             logger.debug(f"Pushed account {account.id} tied to item {account.item.id}")
+
+    def set_user_active_status(self, username: str, is_active: bool):
+        user = self.user_repo.get_user_by_username(username=username)
+        user.is_active = is_active
+        self.user_repo.set_active_status(user, is_active)

--- a/purch/infrastructure/auth/service.py
+++ b/purch/infrastructure/auth/service.py
@@ -81,6 +81,18 @@ def create_purch_jwt_access_token(
     return encoded_jwt
 
 
+def verify_purch_jwt_token(token: str, settings: Settings) -> dict:
+    try:
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY.get_secret_value(),
+            algorithms=[settings.ALGORITHM],
+        )
+        return payload
+    except JWTError as e:
+        raise JWTError(f"Token validation failed: {str(e)}")
+
+
 def get_current_user(
     request: Request,
     settings: Annotated[Settings, Depends(get_settings)],
@@ -99,13 +111,13 @@ def get_current_user(
     if auth_header and auth_header.startswith("Bearer "):
         token = auth_header.split(" ", 1)[1]
     else:
-        # Fallback to cookie
-        token = request.cookies.get("access_token")
+        token = request.cookies.get(settings.AUTH_COOKIE_NAME)
 
     if not token:
         raise credentials_exception
 
     try:
+        verify_purch_jwt_token(token, settings)
         payload = jwt.decode(
             token,
             settings.SECRET_KEY.get_secret_value(),

--- a/purch/infrastructure/auth/service.py
+++ b/purch/infrastructure/auth/service.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Optional, Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from passlib.context import CryptContext
 from jose import jwt, JWTError
@@ -82,34 +82,47 @@ def create_purch_jwt_access_token(
 
 
 def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)],
+    request: Request,
     settings: Annotated[Settings, Depends(get_settings)],
 ) -> User:
-    """Decode JWT token and return current user."""
+    """Get current user from either Authorization header or httpOnly cookie."""
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
 
+    # Try to get token from Authorization header
+    auth_header = request.headers.get("Authorization")
+    token = None
+
+    if auth_header and auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1]
+    else:
+        # Fallback to cookie
+        token = request.cookies.get("access_token")
+
+    if not token:
+        raise credentials_exception
+
     try:
-        # Decode JWT token
         payload = jwt.decode(
             token,
             settings.SECRET_KEY.get_secret_value(),
             algorithms=[settings.ALGORITHM],
         )
         user_id: str = payload.get("sub")
-        if user_id is None:
+        if not user_id:
             raise credentials_exception
     except JWTError:
         raise credentials_exception
 
-    # Get user from database
     user_repo = UserRepository(settings=settings)
     user = user_repo.get_user_by_id(id=user_id)
-    if user is None:
+
+    if not user:
         raise credentials_exception
+
     return user
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def test_user():
     )
 
     test_user_dict = test_user.model_dump()
-    test_user_dict["salary"] = float(test_user_dict["salary"])
+    test_user_dict["income"] = float(test_user_dict["income"])
     test_user_dict["id"] = test_user_dict["id"].hex
 
     create_user = UserCreate(
@@ -118,10 +118,10 @@ async def unauthenticated_test_client(configure_test_settings):
 def configure_test_settings(request, monkeypatch, test_db_name):
     """
     Configure test database settings and ensure all modules use the test settings.
-    
+
     This fixture:
     1. Clears the settings cache to ensure fresh settings
-    2. Sets a unique POSTGRES_DATABASE environment variable 
+    2. Sets a unique POSTGRES_DATABASE environment variable
     3. Creates a new Settings instance with the test database name
     4. Patches all modules that use settings to use our test instance
     5. Yields the test_settings object for use in tests
@@ -129,16 +129,16 @@ def configure_test_settings(request, monkeypatch, test_db_name):
     """
     # Clear the cached settings to ensure we get a fresh instance
     get_settings.cache_clear()
-    
+
     # Set the environment variable
     test_db_name = test_db_name
     monkeypatch.setenv("POSTGRES_DATABASE", test_db_name)
     monkeypatch.setenv("POSTGRES_HOST", "test-postgres")
     monkeypatch.setenv("REDIS_HOST", "test-redis")
-    
+
     # Create new settings instance (will pick up the environment variables)
     test_settings = Settings()
-    
+
     # Ensure all modules use our test settings
     modules_to_patch = [
         "purch.api.startup.get_settings",
@@ -151,11 +151,11 @@ def configure_test_settings(request, monkeypatch, test_db_name):
         "purch.infrastructure.taskiq.tasks.get_settings",
         "purch.domains.user.service.get_settings",
     ]
-    
+
     # Use lambda to ensure the same instance is returned each time
     for module in modules_to_patch:
         monkeypatch.setattr(module, lambda: test_settings)
-    
+
     # The taskiq module will automatically use InMemoryBroker for tests
     # based on the test database name pattern
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -54,8 +54,8 @@ async def test_user_update(configure_test_settings, authenticated_test_client, t
     assert user.id == update_response["id"]
     assert update_response["first_name"] == "Bofa"
     assert update_response["last_name"] == "Grover"
-    assert update_response["salary"] == user.salary
-    assert update_response["salary_rate"] == user.salary_rate
+    assert update_response["income"] == user.income
+    assert update_response["income_rate"] == user.income_rate
 
 # TODO: figure out why this is failing
 @pytest.mark.skip
@@ -63,7 +63,7 @@ async def test_valid_user_login(configure_test_settings, authenticated_test_clie
     """Test successful login with valid credentials using the OAuth2PasswordRequestForm format."""
     # Create a test user
     user, _, _ = test_user
-    
+
     # Now hit the login endpoint with form data (mimicking OAuth2PasswordRequestForm)
     login_response = await authenticated_test_client.post(
         TOKEN_URL,
@@ -73,11 +73,11 @@ async def test_valid_user_login(configure_test_settings, authenticated_test_clie
         },
         headers={"Content-Type": "application/x-www-form-urlencoded"}
     )
-    
+
     # Check response status and content
     assert login_response.status_code == status.HTTP_200_OK
     response_data = login_response.json()
-    
+
     # Verify token structure
     assert "access_token" in response_data
     assert "token_type" in response_data
@@ -89,7 +89,7 @@ async def test_invalid_password_login(configure_test_settings, unauthenticated_t
     """Test login failure with invalid password."""
     # Create and register a test user
     test_user, _, _ = test_user
-    
+
     # Try to login with incorrect password
     login_response = await unauthenticated_test_client.post(
         TOKEN_URL,
@@ -99,7 +99,7 @@ async def test_invalid_password_login(configure_test_settings, unauthenticated_t
         },
         headers={"Content-Type": "application/x-www-form-urlencoded"}
     )
-    
+
     # Check we get a 401 Unauthorized response
     assert login_response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -115,7 +115,7 @@ async def test_invalid_username_login(configure_test_settings, unauthenticated_t
         },
         headers={"Content-Type": "application/x-www-form-urlencoded"}
     )
-    
+
     # Check we get a 401 Unauthorized response
     assert login_response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -130,7 +130,7 @@ async def test_unauthenticated_access(configure_test_settings, unauthenticated_t
     # Try to access current user endpoint without a token
     current_user_response = await unauthenticated_test_client.get(CURRENT_USER_URL)
     assert current_user_response.status_code == status.HTTP_401_UNAUTHORIZED
-    
+
     # Try to access delete user endpoint without a token
     delete_user_response = await unauthenticated_test_client.delete(DELETE_USER_URL)
     assert delete_user_response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -150,17 +150,17 @@ async def test_authenticated_current_user(configure_test_settings, unauthenticat
     assert register_response.status_code == status.HTTP_200_OK
     # get token
     token = get_auth_token(test_user, test_settings)
-    
+
     # Access current user endpoint with token
     current_user_response = await unauthenticated_test_client.get(
         CURRENT_USER_URL,
         headers={"Authorization": f"Bearer {token}"}
     )
-    
+
     # Verify response
     assert current_user_response.status_code == status.HTTP_200_OK
     current_user_data = current_user_response.json()
-    
+
     # Verify user data matches
     assert current_user_data["username"] == test_user.username
     assert current_user_data["first_name"] == test_user.first_name
@@ -180,16 +180,16 @@ async def test_delete_own_account(configure_test_settings, unauthenticated_test_
     assert register_response.status_code == status.HTTP_200_OK
     # get token
     token = get_auth_token(test_user, test_settings)
-    
+
     # Delete the user account
     delete_response = await unauthenticated_test_client.delete(
         DELETE_USER_URL,
         headers={"Authorization": f"Bearer {token}"}
     )
-    
+
     # Verify successful deletion
     assert delete_response.status_code == status.HTTP_200_OK
-    
+
     # Verify user can no longer access protected endpoints
     current_user_response = await unauthenticated_test_client.get(
         CURRENT_USER_URL,
@@ -210,4 +210,3 @@ def get_auth_token(test_user, test_settings) -> str:
         expires_delta=token_expiration
     )
     return auth_token
-


### PR DESCRIPTION
## changes:
- separates creates `verify_auth` endpoint separate from `login`
- fixes bugs associated with httpOnly cookies (correctly sets user to false, verifies token inside of cookie now, configurable cookie key in settings)
- removes defaults from user models
- updates salary -> income


## to test:
- run this with the [user-auth UI branch](https://github.com/burchandres/ui-purch/pull/10) and ensure:
- landing page shows when loading without logging in
- create user works, error / success messages pop up according to form data provided
- login works, persists until logout